### PR TITLE
Add Lurk implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Each directory contains a small README detailing the structure of the implementa
 - Gnark (`gnark/`)
 - Halo2 (`halo2/`)
 - Noir (`noir`)
+- Lurk (`lurk`)
 
 ## Disclaimer
 

--- a/lurk/README.md
+++ b/lurk/README.md
@@ -12,7 +12,7 @@ those proofs.
 ### Prerequisites
 Install Lurk:
 ```
-cargo install loam --locked --git https://github.com/argumentcomputer/lurk --rev 417d5da
+cargo install lurk --locked --git https://github.com/argumentcomputer/lurk --rev 3c7e883
 ```
 
 NOTE: it may be necessary to update rust (`rustup update`) in order for the installation to succeed.

--- a/lurk/README.md
+++ b/lurk/README.md
@@ -12,7 +12,7 @@ those proofs.
 ### Prerequisites
 Install Lurk:
 ```
-cargo install loam --locked --git https://github.com/argumentcomputer/lurk --rev 058396e
+cargo install loam --locked --git https://github.com/argumentcomputer/lurk --rev 417d5da
 ```
 
 NOTE: it may be necessary to update rust (`rustup update`) in order for the installation to succeed.

--- a/lurk/README.md
+++ b/lurk/README.md
@@ -4,15 +4,15 @@
 
 The implementation in `mastermind.lurk` is self-contained. The first 48 lines implement the scoring function. These are
 followed by some inline tests, in the form of assertions. Loading the file will exit with an error if an assertion
-fails. The final lines create proofs-of-evaluation of the expressions invoking the scoring function. These can be
-verified interactively from the Lurk REPL.
+fails. The final lines create proofs-of-evaluation of the expressions invoking the scoring function and then verify
+those proofs.
 
 ## Running the Examples
 
 ### Prerequisites
 Install Lurk:
 ```
-cargo install loam --locked --git https://github.com/argumentcomputer/lurk --rev 65d33a0
+cargo install loam --locked --git https://github.com/argumentcomputer/lurk --rev 058396e
 ```
 
 NOTE: it may be necessary to update rust (`rustup update`) in order for the installation to succeed.
@@ -20,14 +20,5 @@ NOTE: it may be necessary to update rust (`rustup update`) in order for the inst
 ### Command Line Instructions
 
 ```shell
-lurk --preload mastermind.lurk
-```
-
-The command above will start Lurk's REPL and run `mastermind.lurk`.
-
-To verify a proof, call the `verify` meta command and provide its key.
-
-Example:
-```lisp
-!(verify "abcd1234...")
+lurk mastermind.lurk
 ```

--- a/lurk/README.md
+++ b/lurk/README.md
@@ -1,0 +1,33 @@
+# Mastermind (Lurk)
+
+## Code Structure
+
+The implementation in `mastermind.lurk` is self-contained. The first 48 lines implement the scoring function. These are
+followed by some inline tests, in the form of assertions. Loading the file will exit with an error if an assertion
+fails. The final lines create proofs-of-evaluation of the expressions invoking the scoring function. These can be
+verified interactively from the Lurk REPL.
+
+## Running the Examples
+
+### Prerequisites
+Install Lurk:
+```
+cargo install loam --locked --git https://github.com/argumentcomputer/lurk --rev 65d33a0
+```
+
+NOTE: it may be necessary to update rust (`rustup update`) in order for the installation to succeed.
+
+### Command Line Instructions
+
+```shell
+lurk --preload mastermind.lurk
+```
+
+The command above will start Lurk's REPL and run `mastermind.lurk`.
+
+To verify a proof, call the `verify` meta command and provide its key.
+
+Example:
+```lisp
+!(verify "abcd1234...")
+```

--- a/lurk/mastermind.lurk
+++ b/lurk/mastermind.lurk
@@ -1,0 +1,61 @@
+!(defrec length (lambda (l) (if l (+ 1 (length (cdr l))) 0)))
+
+;; Returns a pair: a boolean that is true if elt was removed from list; and the remaining elements in reverse order.
+!(def maybe-remove (lambda (elt list)
+                     (letrec ((aux (lambda (removed? acc elt list remaining)
+                                     (if (> remaining 0)
+                                         (if (eq elt (car list))
+                                             (aux t
+                                                  (if removed? (cons (car list) acc) acc)
+                                                  elt
+                                                  (if removed? list (cdr list))
+                                                  (- remaining 1))
+                                             (aux removed? (cons (car list) acc) elt (cdr list) (- remaining 1)))
+                                         (cons removed? acc)))))
+                       (aux nil () elt list (length list)))))
+
+!(def score (lambda (code guess)
+              (letrec ((aux (lambda (hits code-miss guess-miss code guess)
+                              (if code
+                                  (if (eq (car code) (car guess))
+                                      (aux (+ 1 hits) code-miss guess-miss (cdr code) (cdr guess))
+                                      (aux hits (cons (car code) code-miss) (cons (car guess) guess-miss) (cdr code) (cdr guess)))
+                                  (letrec ((aux2 (lambda (partial-hits code-miss guess-miss)
+                                                   (if code-miss
+                                                       (let ((removed?-remaining (maybe-remove (car code-miss) guess-miss)))
+                                                         (if (car removed?-remaining)
+                                                             (aux2 (+ 1 partial-hits) (cdr code-miss) (cdr removed?-remaining))
+                                                             (aux2 partial-hits (cdr code-miss) guess-miss)))
+                                                       partial-hits))))
+                                    (cons hits (aux2 0 code-miss guess-miss)))))))
+                (aux 0 () () code guess))))
+
+!(def code-valid? (lambda (code expected-length num-choices)
+                    (if (= expected-length (length code))
+                        (letrec ((aux (lambda (code)
+                                        (if code
+                                            (if (< (car code) num-choices)
+                                                (if (>= (car code) 0)
+                                                    (aux (cdr code))))
+                                            t))))
+                          (aux code)))))
+
+!(def score-one-turn (lambda (code-commitment code-length num-choices guess)
+                        (if (code-valid? (open code-commitment) code-length num-choices)
+                            (if (code-valid? guess code-length num-choices)
+                                (score (open code-commitment) guess)
+                                :bad-guess)
+                            :bad-code)))
+
+;; Tests just to show that the implementation behaves as expected.
+;; Note that #0x42 and #0x43 are weak secrets and could easily be brute-forced by a naive algorithm.
+!(assert-eq '(1 . 2) (score-one-turn (hide #0x42 '(1 2 3 4)) 4 6 '(0 2 4 3)))
+!(assert-eq '(0 . 0) (score-one-turn (hide #0x43 '(0 0 0 0)) 4 6 '(1 2 3 4)))
+!(assert-eq :bad-code (score-one-turn (hide #0x42 '(1 2 3 9)) 4 6 '(0 2 4 3)))
+!(assert-eq :bad-guess (score-one-turn (hide #0x42 '(1 2 3 4)) 4 6 '(9 2 4 3)))
+
+;; Actually proving calls to the scoring function
+!(prove (score-one-turn (hide #0x42 '(1 2 3 4)) 4 6 '(0 2 4 3)))
+!(prove (score-one-turn (hide #0x43 '(0 0 0 0)) 4 6 '(1 2 3 4)))
+!(prove (score-one-turn (hide #0x42 '(1 2 3 9)) 4 6 '(0 2 4 3)))
+!(prove (score-one-turn (hide #0x42 '(1 2 3 4)) 4 6 '(9 2 4 3)))

--- a/lurk/mastermind.lurk
+++ b/lurk/mastermind.lurk
@@ -55,7 +55,13 @@
 !(assert-eq :bad-guess (score-one-turn (hide #0x42 '(1 2 3 4)) 4 6 '(9 2 4 3)))
 
 ;; Actually proving calls to the scoring function
-!(prove (score-one-turn (hide #0x42 '(1 2 3 4)) 4 6 '(0 2 4 3)))
-!(prove (score-one-turn (hide #0x43 '(0 0 0 0)) 4 6 '(1 2 3 4)))
-!(prove (score-one-turn (hide #0x42 '(1 2 3 9)) 4 6 '(0 2 4 3)))
-!(prove (score-one-turn (hide #0x42 '(1 2 3 4)) 4 6 '(9 2 4 3)))
+!(def proof-key-1-2 !(prove (score-one-turn (hide #0x42 '(1 2 3 4)) 4 6 '(0 2 4 3))))
+!(def proof-key-0-0 !(prove (score-one-turn (hide #0x43 '(0 0 0 0)) 4 6 '(1 2 3 4))))
+!(def proof-key-bad-code !(prove (score-one-turn (hide #0x42 '(1 2 3 9)) 4 6 '(0 2 4 3))))
+!(def proof-key-bad-guess !(prove (score-one-turn (hide #0x42 '(1 2 3 4)) 4 6 '(9 2 4 3))))
+
+;; Verifying the proofs by their keys
+!(assert !(verify proof-key-1-2))
+!(assert !(verify proof-key-0-0))
+!(assert !(verify proof-key-bad-code))
+!(assert !(verify proof-key-bad-guess))

--- a/lurk/mastermind.lurk
+++ b/lurk/mastermind.lurk
@@ -51,12 +51,12 @@
 !(def code-comm-1 (hide !(rand) '(1 2 3 4)))
 !(def code-comm-2 (hide !(rand) '(0 0 0 0)))
 !(def code-comm-3 (hide !(rand) '(1 2 3 9)))
+
 ;; Tests to show that the implementation behaves as expected.
 !(assert-eq '(1 . 2) (score-one-turn code-comm-1 4 6 '(0 2 4 3)))
 !(assert-eq '(0 . 0) (score-one-turn code-comm-2 4 6 '(1 2 3 4)))
 !(assert-eq :bad-code (score-one-turn code-comm-3 4 6 '(0 2 4 3)))
 !(assert-eq :bad-guess (score-one-turn code-comm-1 4 6 '(9 2 4 3)))
-
 
 ;; Actually proving calls to the scoring function
 !(def proof-key-1-2 !(prove (score-one-turn code-comm-1 4 6 '(0 2 4 3))))

--- a/lurk/mastermind.lurk
+++ b/lurk/mastermind.lurk
@@ -47,18 +47,22 @@
                                 :bad-guess)
                             :bad-code)))
 
-;; Tests just to show that the implementation behaves as expected.
-;; Note that #0x42 and #0x43 are weak secrets and could easily be brute-forced by a naive algorithm.
-!(assert-eq '(1 . 2) (score-one-turn (hide #0x42 '(1 2 3 4)) 4 6 '(0 2 4 3)))
-!(assert-eq '(0 . 0) (score-one-turn (hide #0x43 '(0 0 0 0)) 4 6 '(1 2 3 4)))
-!(assert-eq :bad-code (score-one-turn (hide #0x42 '(1 2 3 9)) 4 6 '(0 2 4 3)))
-!(assert-eq :bad-guess (score-one-turn (hide #0x42 '(1 2 3 4)) 4 6 '(9 2 4 3)))
+;; Note that !(rand) produces strong secrets that cannot be brute-forced.
+!(def code-comm-1 (hide !(rand) '(1 2 3 4)))
+!(def code-comm-2 (hide !(rand) '(0 0 0 0)))
+!(def code-comm-3 (hide !(rand) '(1 2 3 9)))
+;; Tests to show that the implementation behaves as expected.
+!(assert-eq '(1 . 2) (score-one-turn code-comm-1 4 6 '(0 2 4 3)))
+!(assert-eq '(0 . 0) (score-one-turn code-comm-2 4 6 '(1 2 3 4)))
+!(assert-eq :bad-code (score-one-turn code-comm-3 4 6 '(0 2 4 3)))
+!(assert-eq :bad-guess (score-one-turn code-comm-1 4 6 '(9 2 4 3)))
+
 
 ;; Actually proving calls to the scoring function
-!(def proof-key-1-2 !(prove (score-one-turn (hide #0x42 '(1 2 3 4)) 4 6 '(0 2 4 3))))
-!(def proof-key-0-0 !(prove (score-one-turn (hide #0x43 '(0 0 0 0)) 4 6 '(1 2 3 4))))
-!(def proof-key-bad-code !(prove (score-one-turn (hide #0x42 '(1 2 3 9)) 4 6 '(0 2 4 3))))
-!(def proof-key-bad-guess !(prove (score-one-turn (hide #0x42 '(1 2 3 4)) 4 6 '(9 2 4 3))))
+!(def proof-key-1-2 !(prove (score-one-turn code-comm-1 4 6 '(0 2 4 3))))
+!(def proof-key-0-0 !(prove (score-one-turn code-comm-2 4 6 '(1 2 3 4))))
+!(def proof-key-bad-code !(prove (score-one-turn code-comm-3 4 6 '(0 2 4 3))))
+!(def proof-key-bad-guess !(prove (score-one-turn code-comm-1 4 6 '(9 2 4 3))))
 
 ;; Verifying the proofs by their keys
 !(assert !(verify proof-key-1-2))


### PR DESCRIPTION
This PR adds a directory for a [Lurk](https://github.com/argumentcomputer/lurk) implementation.

The first 48 lines of `mastermind.lurk` provide the actual implementation, setting an upper bound on the LOC (whose exact value depends on how you've chosen to measure).

The remainder provides some inline tests and generates proofs. The proofs can be verified from the Lurk REPL as described in the README.